### PR TITLE
Playwright - fix miliseconds converter and typos

### DIFF
--- a/Plugins/SpecFlow.Actions.Playwright/SpecFlow.Actions.Playwright/BrowserDriver.cs
+++ b/Plugins/SpecFlow.Actions.Playwright/SpecFlow.Actions.Playwright/BrowserDriver.cs
@@ -18,19 +18,19 @@ namespace SpecFlow.Actions.Playwright
         {
             _playwrightConfiguration = playwrightConfiguration;
             _driverInitialiser = driverInitialiser;
-            _currentBrowserLazy = new AsyncLazy<IBrowser>(CreateWebDriverAsync);
+            _currentBrowserLazy = new AsyncLazy<IBrowser>(CreatePlaywrightAsync);
         }
 
         /// <summary>
-        /// The current Selenium IWebDriver instance
+        /// The current Playwright instance
         /// </summary>
         public Task<IBrowser> Current => _currentBrowserLazy.Value;
 
         /// <summary>
-        /// Creates the Selenium web driver (opens a browser)
+        /// Creates a new instance of Playwright (opens a browser)
         /// </summary>
         /// <returns></returns>
-        private async Task<IBrowser> CreateWebDriverAsync()
+        private async Task<IBrowser> CreatePlaywrightAsync()
         {
             return _playwrightConfiguration.Browser switch
             {
@@ -43,7 +43,7 @@ namespace SpecFlow.Actions.Playwright
         }
 
         /// <summary>
-        /// Disposes the Selenium web driver (closing the browser)
+        /// Disposes the Playwright instance (closing the browser)
         /// </summary>
         public void Dispose()
         {

--- a/Plugins/SpecFlow.Actions.Playwright/SpecFlow.Actions.Playwright/DriverInitialiser.cs
+++ b/Plugins/SpecFlow.Actions.Playwright/SpecFlow.Actions.Playwright/DriverInitialiser.cs
@@ -42,7 +42,7 @@ namespace SpecFlow.Actions.Playwright
 
         public async Task<IBrowser> GetChromiumDriverAsync(string[]? args, float? timeout = 30, bool? headless = true)
         {
-            var options = new BrowserTypeLaunchOptions { Args = args, Timeout = ToMilliseconds(timeout), Headless = headless};
+            var options = new BrowserTypeLaunchOptions { Args = args, Timeout = ToMilliseconds(timeout), Headless = headless };
 
             var playwright = await Microsoft.Playwright.Playwright.CreateAsync();
 
@@ -51,7 +51,7 @@ namespace SpecFlow.Actions.Playwright
 
         private static float? ToMilliseconds(float? seconds)
         {
-            return seconds * 10000;
+            return seconds * 1000;
         }
     }
 }


### PR DESCRIPTION
- ToMiliseconds returned a higher value by intended (10x than it should, so the default timeout was 300 seconds, not 30)
- fixed some typos referencing the code to the original Selenium solution
