### PR TITLE
WindowsAppDriverPath not required if executing from CI/CD (Azure)

### DIFF
--- a/Plugins/SpecFlow.Actions.WindowsAppDriver/Example/Specflow.Actions.json
+++ b/Plugins/SpecFlow.Actions.WindowsAppDriver/Example/Specflow.Actions.json
@@ -2,7 +2,6 @@
   "windowsAppDriver": {
     "capabilities": {
       "app": "../SpecFlowCalculator/bin/Debug/net5.0-windows/SpecFlowCalculator.exe"
-    } //,
-    //"WindowsAppDriverPath": "REQUIRED FOR LOCAL EXECUTION UNLESS YOU SPECIFY THE ENVIRONMENT VARIABLE {WINDOWS_APP_DRIVER_EXECUTABLE_PATH}"
-  } 
+    }
+  }
 }

--- a/Plugins/SpecFlow.Actions.WindowsAppDriver/Example/Specflow.Actions.json
+++ b/Plugins/SpecFlow.Actions.WindowsAppDriver/Example/Specflow.Actions.json
@@ -2,7 +2,7 @@
   "windowsAppDriver": {
     "capabilities": {
       "app": "../SpecFlowCalculator/bin/Debug/net5.0-windows/SpecFlowCalculator.exe"
-    },
-    "WindowsAppDriverPath": "{the path to windows app driver}"
+    } //,
+    //"WindowsAppDriverPath": "REQUIRED FOR LOCAL EXECUTION UNLESS YOU SPECIFY THE ENVIRONMENT VARIABLE {WINDOWS_APP_DRIVER_EXECUTABLE_PATH}"
   } 
 }

--- a/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/AppDriverCLI.cs
+++ b/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/AppDriverCLI.cs
@@ -6,9 +6,6 @@ namespace SpecFlow.Actions.WindowsAppDriver
 {
     public class AppDriverCli : IAppDriverCli
     {
-        private const string Error = 
-            "There was an issue launching WindowsAppDriver.exe, please make sure the correct file path is included in Specflow.Actions.json or that the 'WINDOWS_APP_DRIVER_FILE_PATH' variable is defined";
-
         private readonly IWindowsAppDriverConfiguration _windowsAppDriverConfiguration;
 
         private Process? _appDriverProcess;
@@ -23,10 +20,13 @@ namespace SpecFlow.Actions.WindowsAppDriver
         /// </summary>
         public void Start()
         {
-            _appDriverProcess = Process.Start((
-                _windowsAppDriverConfiguration.WindowsAppDriverPath 
-                ?? Environment.GetEnvironmentVariable("WINDOWS_APP_DRIVER_EXECUTABLE_PATH")) 
-                ?? throw new InvalidOperationException(Error));
+            var path = _windowsAppDriverConfiguration.WindowsAppDriverPath ??
+                       Environment.GetEnvironmentVariable("WINDOWS_APP_DRIVER_EXECUTABLE_PATH") ?? null;
+
+            if (path != null)
+            {
+                _appDriverProcess = Process.Start(path); 
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Windows app driver needs to be installed via a build task in azure if executing via CI/CD, so the process does not need to be in inside of the code. Added a condition to skip Process.Start() if the config value or the environment variables return null for the app driver file path