### PR TITLE
[feature] add configuration traceDir support

### DIFF
--- a/Plugins/SpecFlow.Actions.Playwright/Example/Hooks/CalculatorHooks.cs
+++ b/Plugins/SpecFlow.Actions.Playwright/Example/Hooks/CalculatorHooks.cs
@@ -1,4 +1,6 @@
 ﻿using Example.PageObjects;
+using Microsoft.Playwright;
+using System.Threading.Tasks;
 using TechTalk.SpecFlow;
 
 namespace Example.Hooks
@@ -9,6 +11,13 @@ namespace Example.Hooks
     [Binding]
     public class CalculatorHooks
     {
+        private readonly string _traceName;
+
+        public CalculatorHooks(ScenarioContext scenarioContext)
+        {
+            _traceName = scenarioContext.ScenarioInfo.Title.Replace(" ", "_");
+        }
+
         ///<summary>
         ///  Reset the calculator before each scenario tagged with "Calculator"
         /// </summary>
@@ -17,5 +26,28 @@ namespace Example.Hooks
         {
             await calculatorPageObject.EnsureCalculatorIsOpenAndResetAsync();
         }
+        
+        [BeforeScenario]
+        public async Task StartTracingAsync(CalculatorPageObject calculatorPageObject)
+        {
+            var tracing = await calculatorPageObject.Tracing;
+            await tracing.StartAsync(new TracingStartOptions
+            {
+                Name = _traceName,
+                Screenshots = true,
+                Snapshots = true
+            });
+        }
+
+        [AfterScenario]
+        public async Task StopTracingAsync(CalculatorPageObject calculatorPageObject)
+        {
+            var tracing = await calculatorPageObject.Tracing;
+            await tracing.StopAsync(new TracingStopOptions()
+            {
+                Path = $"traces/{_traceName}.zip"
+            });
+        }
+
     }
 }

--- a/Plugins/SpecFlow.Actions.Playwright/Example/PageObjects/BasePage.cs
+++ b/Plugins/SpecFlow.Actions.Playwright/Example/PageObjects/BasePage.cs
@@ -6,17 +6,29 @@ namespace Example.PageObjects
 {
     public class BasePage
     {
+        public readonly Task<IBrowserContext> _browserContext;
+        private readonly Task<ITracing> _tracing;
         public readonly Task<IPage> _page;
 
+        public Task<ITracing> Tracing => _tracing;
+        
         public BasePage(BrowserDriver browserDriver)
         {
-            _page = CreatePageAsync(browserDriver.Current);
+            _browserContext = CreateBrowserContextAsync(browserDriver.Current);
+            _tracing = _browserContext.ContinueWith(t => t.Result.Tracing);
+            _page = CreatePageAsync(_browserContext);
+            
         }
 
-        private async Task<IPage> CreatePageAsync(Task<IBrowser> browser)
+        private async Task<IBrowserContext> CreateBrowserContextAsync(Task<IBrowser> browser)
         {
-            // Creates a new page instance
-            return await (await browser).NewPageAsync();
+            return await (await browser).NewContextAsync();
         }
+
+        private async Task<IPage> CreatePageAsync(Task<IBrowserContext> browserContext)
+        {
+            return await (await browserContext).NewPageAsync();
+        }
+
     }
 }

--- a/Plugins/SpecFlow.Actions.Playwright/Example/specflow.actions.json
+++ b/Plugins/SpecFlow.Actions.Playwright/Example/specflow.actions.json
@@ -2,6 +2,7 @@
   "playwright": {
     "browser": "chrome",
     "defaultTimeout": 60,
-    "headless": false
+    "headless": false,
+    "traceDir": "traces"
   }
 }

--- a/Plugins/SpecFlow.Actions.Playwright/Readme.md
+++ b/Plugins/SpecFlow.Actions.Playwright/Readme.md
@@ -35,7 +35,8 @@ You can configure this plugin via the  `specflow.actions.json`.
     ],
     "defaultTimeout": 60,
     "headless": false,
-    "slowmo": 100
+    "slowmo": 100,
+    "traceDir": "traces"
   }
 }
 ```
@@ -62,6 +63,11 @@ Whether the browser should run in headless mode or not.
 ### slowmo
 
 Optional. Expressed in miliseconds. If present, will reflect Playwright's slowmo functionality, which determines the time between each individual actions are made, like clicking or typing.
+
+### traceDir
+
+Optional. If [specified](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-traces-dir), traces are saved into this directory. 
+See also [record traces](https://playwright.dev/dotnet/docs/trace-viewer#recording-a-trace).
 
 ## How to use it
 

--- a/Plugins/SpecFlow.Actions.Playwright/SpecFlow.Actions.Playwright/BrowserDriver.cs
+++ b/Plugins/SpecFlow.Actions.Playwright/SpecFlow.Actions.Playwright/BrowserDriver.cs
@@ -34,11 +34,11 @@ namespace SpecFlow.Actions.Playwright
         {
             return _playwrightConfiguration.Browser switch
             {
-                Browser.Chrome => await _driverInitialiser.GetChromeDriverAsync(_playwrightConfiguration.Arguments, _playwrightConfiguration.DefaultTimeout, _playwrightConfiguration.Headless, _playwrightConfiguration.SlowMo),
-                Browser.Firefox => await _driverInitialiser.GetFirefoxDriverAsync(_playwrightConfiguration.Arguments, _playwrightConfiguration.DefaultTimeout, _playwrightConfiguration.Headless, _playwrightConfiguration.SlowMo),
-                Browser.Edge => await _driverInitialiser.GetEdgeDriverAsync(_playwrightConfiguration.Arguments, _playwrightConfiguration.DefaultTimeout, _playwrightConfiguration.Headless, _playwrightConfiguration.SlowMo),
-                Browser.Chromium => await _driverInitialiser.GetChromiumDriverAsync(_playwrightConfiguration.Arguments, _playwrightConfiguration.DefaultTimeout, _playwrightConfiguration.Headless, _playwrightConfiguration.SlowMo),
-                Browser.Webkit => await _driverInitialiser.GetWebKitDriverAsync(_playwrightConfiguration.Arguments, _playwrightConfiguration.DefaultTimeout, _playwrightConfiguration.Headless, _playwrightConfiguration.SlowMo),
+                Browser.Chrome => await _driverInitialiser.GetChromeDriverAsync(_playwrightConfiguration.Arguments, _playwrightConfiguration.DefaultTimeout, _playwrightConfiguration.Headless, _playwrightConfiguration.SlowMo, _playwrightConfiguration.TraceDir),
+                Browser.Firefox => await _driverInitialiser.GetFirefoxDriverAsync(_playwrightConfiguration.Arguments, _playwrightConfiguration.DefaultTimeout, _playwrightConfiguration.Headless, _playwrightConfiguration.SlowMo, _playwrightConfiguration.TraceDir),
+                Browser.Edge => await _driverInitialiser.GetEdgeDriverAsync(_playwrightConfiguration.Arguments, _playwrightConfiguration.DefaultTimeout, _playwrightConfiguration.Headless, _playwrightConfiguration.SlowMo, _playwrightConfiguration.TraceDir),
+                Browser.Chromium => await _driverInitialiser.GetChromiumDriverAsync(_playwrightConfiguration.Arguments, _playwrightConfiguration.DefaultTimeout, _playwrightConfiguration.Headless, _playwrightConfiguration.SlowMo, _playwrightConfiguration.TraceDir),
+                Browser.Webkit => await _driverInitialiser.GetWebKitDriverAsync(_playwrightConfiguration.Arguments, _playwrightConfiguration.DefaultTimeout, _playwrightConfiguration.Headless, _playwrightConfiguration.SlowMo, _playwrightConfiguration.TraceDir),
                 _ => throw new NotImplementedException($"Support for browser {_playwrightConfiguration.Browser} is not implemented yet"),
             };
         }

--- a/Plugins/SpecFlow.Actions.Playwright/SpecFlow.Actions.Playwright/DriverInitialiser.cs
+++ b/Plugins/SpecFlow.Actions.Playwright/SpecFlow.Actions.Playwright/DriverInitialiser.cs
@@ -5,57 +5,57 @@ namespace SpecFlow.Actions.Playwright
 {
     public interface IDriverInitialiser
     {
-        Task<IBrowser> GetChromeDriverAsync(string[]? args = null, float? timeout = DriverInitialiser.DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null);
-        Task<IBrowser> GetEdgeDriverAsync(string[]? args = null, float? timeout = DriverInitialiser.DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null);
-        Task<IBrowser> GetFirefoxDriverAsync(string[]? args = null, float? timeout = DriverInitialiser.DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null);
-        Task<IBrowser> GetChromiumDriverAsync(string[]? args = null, float? timeout = DriverInitialiser.DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null);
-        Task<IBrowser> GetWebKitDriverAsync(string[]? args = null, float? timeout = DriverInitialiser.DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null);
+        Task<IBrowser> GetChromeDriverAsync(string[]? args = null, float? timeout = DriverInitialiser.DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null, string? traceDir = null);
+        Task<IBrowser> GetEdgeDriverAsync(string[]? args = null, float? timeout = DriverInitialiser.DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null, string? traceDir = null);
+        Task<IBrowser> GetFirefoxDriverAsync(string[]? args = null, float? timeout = DriverInitialiser.DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null, string? traceDir = null);
+        Task<IBrowser> GetChromiumDriverAsync(string[]? args = null, float? timeout = DriverInitialiser.DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null, string? traceDir = null);
+        Task<IBrowser> GetWebKitDriverAsync(string[]? args = null, float? timeout = DriverInitialiser.DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null, string? traceDir = null);
     }
 
     public class DriverInitialiser : IDriverInitialiser
     {
         public const float DEFAULT_TIMEOUT = 30f;
 
-        public async Task<IBrowser> GetChromeDriverAsync(string[]? args = null, float? timeout = DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null)
+        public async Task<IBrowser> GetChromeDriverAsync(string[]? args = null, float? timeout = DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null, string? traceDir = null)
         {
-            var options = GetOptions(args, timeout, headless, slowmo);
+            var options = GetOptions(args, timeout, headless, slowmo, traceDir);
             options.Channel = "chrome";
 
             return await GetBrowserAsync(BrowserType.Chromium, options);
         }
 
-        public async Task<IBrowser> GetFirefoxDriverAsync(string[]? args = null, float? timeout = DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null)
+        public async Task<IBrowser> GetFirefoxDriverAsync(string[]? args = null, float? timeout = DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null, string? traceDir = null)
         {
-            var options = GetOptions(args, timeout, headless, slowmo);
+            var options = GetOptions(args, timeout, headless, slowmo, traceDir);
 
             return await GetBrowserAsync(BrowserType.Firefox, options);
         }
 
-        public async Task<IBrowser> GetEdgeDriverAsync(string[]? args = null, float? timeout = DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null)
+        public async Task<IBrowser> GetEdgeDriverAsync(string[]? args = null, float? timeout = DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null, string? traceDir = null)
         {
-            var options = GetOptions(args, timeout, headless, slowmo);
+            var options = GetOptions(args, timeout, headless, slowmo, traceDir);
             options.Channel = "msedge";
 
             return await GetBrowserAsync(BrowserType.Chromium, options);
         }
 
-        public async Task<IBrowser> GetChromiumDriverAsync(string[]? args, float? timeout = DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null)
+        public async Task<IBrowser> GetChromiumDriverAsync(string[]? args, float? timeout = DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null, string? traceDir = null)
         {
-            var options = GetOptions(args, timeout, headless, slowmo);
+            var options = GetOptions(args, timeout, headless, slowmo, traceDir);
 
             return await GetBrowserAsync(BrowserType.Chromium, options);
         }
 
-        public async Task<IBrowser> GetWebKitDriverAsync(string[]? args, float? timeout = DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null)
+        public async Task<IBrowser> GetWebKitDriverAsync(string[]? args, float? timeout = DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null, string? traceDir = null)
         {
-            var options = GetOptions(args, timeout, headless, slowmo);
+            var options = GetOptions(args, timeout, headless, slowmo, traceDir);
 
             return await GetBrowserAsync(BrowserType.Webkit, options);
         }
 
-        private BrowserTypeLaunchOptions GetOptions(string[]? args, float? timeout = DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null)
+        private BrowserTypeLaunchOptions GetOptions(string[]? args, float? timeout = DEFAULT_TIMEOUT, bool? headless = true, float? slowmo = null, string? traceDir = null)
             => new()
-            { Args = args, Timeout = ToMilliseconds(timeout), Headless = headless, SlowMo = slowmo };
+            { Args = args, Timeout = ToMilliseconds(timeout), Headless = headless, SlowMo = slowmo, TracesDir = traceDir};
 
         private async Task<IBrowser> GetBrowserAsync(string browserType, BrowserTypeLaunchOptions options)
         {

--- a/Plugins/SpecFlow.Actions.Playwright/SpecFlow.Actions.Playwright/PlaywrightConfiguration.cs
+++ b/Plugins/SpecFlow.Actions.Playwright/SpecFlow.Actions.Playwright/PlaywrightConfiguration.cs
@@ -16,6 +16,8 @@ namespace SpecFlow.Actions.Playwright
         bool? Headless { get; }
 
         float? SlowMo { get; }
+        
+        string? TraceDir { get; }
     }
 
     public class PlaywrightConfiguration : IPlaywrightConfiguration
@@ -44,6 +46,9 @@ namespace SpecFlow.Actions.Playwright
 
             [JsonInclude]
             public float? SlowMo { get; private set; }
+
+            [JsonInclude]
+            public string? TraceDir { get; private set; }
         }
 
         private readonly Lazy<SpecFlowActionJson> _specflowJsonPart;
@@ -103,5 +108,10 @@ namespace SpecFlow.Actions.Playwright
         /// How many miliseconds elapse between every action 
         /// </summary>
         public float? SlowMo => _specflowJsonPart.Value.Playwright.SlowMo;
+
+        /// <summary>
+        /// If specified, traces are saved into this directory 
+        /// </summary>
+        public string? TraceDir => _specflowJsonPart.Value.Playwright.TraceDir;
     }
 }


### PR DESCRIPTION
Hello,

Playwright traces are a very cool feature. Here is a small PR to support it :).

 * adds the support for the [traceDir](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-traces-dir) option
 * updates the example to show how to use it

Regards,
Yann