### PR TITLE
Handle appWorkingDir same way as app in specflow.actions.json

### DIFF
--- a/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/WindowsAppDriverOptions.cs
+++ b/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/WindowsAppDriverOptions.cs
@@ -34,7 +34,8 @@ namespace SpecFlow.Actions.WindowsAppDriver
 
             foreach (var capability in _windowsAppDriverConfiguration.Capabilities)
             {
-                if (string.Equals(capability.Key, "app", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(capability.Key, "app", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(capability.Key, "appWorkingDir", StringComparison.OrdinalIgnoreCase))
                 {
                     options.AddAdditionalCapability(capability.Key, Path.Combine(Directory.GetCurrentDirectory(), capability.Value));
                 }


### PR DESCRIPTION
This adds conversion of a referential path to a full path for appWorkingDir capability when set in specflow.actions.json.

See: #101 