### PR TITLE
Updated dotnet version in the config file

### DIFF
--- a/Plugins/SpecFlow.Actions.WindowsAppDriver/Example/Specflow.Actions.json
+++ b/Plugins/SpecFlow.Actions.WindowsAppDriver/Example/Specflow.Actions.json
@@ -1,7 +1,7 @@
 {
   "windowsAppDriver": {
     "capabilities": {
-      "app": "../SpecFlowCalculator/bin/Debug/net5.0-windows/SpecFlowCalculator.exe"
+      "app": "../SpecFlowCalculator/bin/Debug/net6.0-windows/SpecFlowCalculator.exe"
     },
     "WindowsAppDriverPath": "C:/Program Files (x86)/Windows Application Driver/WinAppDriver.exe",
     "EnableScreenshots": true


### PR DESCRIPTION
The winforms project now targets the .net 6 version, but the test config is still trying to run the .net 5 debug version