### PR TITLE
Win app driver improvements

### DIFF
--- a/Plugins/SpecFlow.Actions.Appium/SpecFlow.Actions.Appium/Configuration/WindowsAppDriver/IWindowsAppDriverConfiguration.cs
+++ b/Plugins/SpecFlow.Actions.Appium/SpecFlow.Actions.Appium/Configuration/WindowsAppDriver/IWindowsAppDriverConfiguration.cs
@@ -8,6 +8,10 @@ namespace SpecFlow.Actions.Appium.Configuration.WindowsAppDriver
 
         string? WindowsAppDriverPath { get; }
 
+        int? WindowsAppDriverPort { get; }
+
         bool? EnableScreenshots { get; }
+
+        bool CloseAppAutomatically { get; }
     }
 }

--- a/Plugins/SpecFlow.Actions.WindowsAppDriver/Example/Specflow.Actions.json
+++ b/Plugins/SpecFlow.Actions.WindowsAppDriver/Example/Specflow.Actions.json
@@ -1,7 +1,7 @@
 {
   "windowsAppDriver": {
     "capabilities": {
-      "app": "../SpecFlowCalculator/bin/Debug/net5.0-windows/SpecFlowCalculator.exe"
+      "app": "../../../../SpecFlowCalculator/bin/Debug/net6.0-windows/SpecFlowCalculator.exe"
     },
     "WindowsAppDriverPath": "C:/Program Files (x86)/Windows Application Driver/WinAppDriver.exe",
     "EnableScreenshots": true

--- a/Plugins/SpecFlow.Actions.WindowsAppDriver/Readme.md
+++ b/Plugins/SpecFlow.Actions.WindowsAppDriver/Readme.md
@@ -28,7 +28,9 @@ Example:
       "app": "../SpecFlowCalculator/bin/Debug/net5.0-windows/SpecFlowCalculator.exe"
     },
     "WindowsAppDriverPath": "C:/Program Files/Windows Application Driver/WinAppDriver.exe",
-    "EnableScreenshots": true
+    "WindowsAppDriverPort": 4723,
+    "EnableScreenshots": true,
+    "CloseAppAutomatically": false
   }
 }
 ```
@@ -49,6 +51,10 @@ Example:
     ```text
     \TestResults\Screenshots\2021-10-11_171822\Calculator\Add two numbers\the first number is 50 (OK).png
     ```
+
+4. ```WindowsAppDriverPort``` - If specified, the Windows App Driver will be launched using this port. If not specified, the default port 4723 will be used. (This setting is useful, if the default port is already in use by another application.)
+
+5. ```CloseAppAutomatically``` - This setting is optional and defaults to `true`. If `false`, the app will not be closed automatically after each scenario.
 
 ### Important information
 

--- a/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/AppDriver.cs
+++ b/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/AppDriver.cs
@@ -7,6 +7,7 @@ namespace SpecFlow.Actions.WindowsAppDriver
 {
     public class AppDriver : IDisposable
     {
+        private const int WindowsAppDriverDefaultPort = 4723;
         private readonly IWindowsAppDriverConfiguration _windowsAppDriverConfiguration;
         private readonly IDriverFactory _driverFactory;
         private readonly IDriverOptions _driverOptions;
@@ -21,7 +22,7 @@ namespace SpecFlow.Actions.WindowsAppDriver
             _windowsAppDriverConfiguration = windowsAppDriverConfiguration;
             _driverFactory = driverFactory;
             _driverOptions = driverOptions;
-            _driverUri = new($"http://127.0.0.1:{windowsAppDriverConfiguration.WindowsAppDriverPort}");
+            _driverUri = new($"http://127.0.0.1:{windowsAppDriverConfiguration.WindowsAppDriverPort.GetValueOrDefault(WindowsAppDriverDefaultPort)}");
             _lazyDriver = new Lazy<WindowsDriver<WindowsElement>>(CreateAppDriver);
         }
 

--- a/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/AppDriver.cs
+++ b/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/AppDriver.cs
@@ -11,7 +11,7 @@ namespace SpecFlow.Actions.WindowsAppDriver
         private readonly IDriverFactory _driverFactory;
         private readonly IDriverOptions _driverOptions;
 
-        private readonly Uri _driverUri = new("http://127.0.0.1:4723/");
+        private readonly Uri _driverUri;
 
         private readonly Lazy<WindowsDriver<WindowsElement>> _lazyDriver;
         private bool _isDisposed;
@@ -21,6 +21,7 @@ namespace SpecFlow.Actions.WindowsAppDriver
             _windowsAppDriverConfiguration = windowsAppDriverConfiguration;
             _driverFactory = driverFactory;
             _driverOptions = driverOptions;
+            _driverUri = new($"http://127.0.0.1:{windowsAppDriverConfiguration.WindowsAppDriverPort}");
             _lazyDriver = new Lazy<WindowsDriver<WindowsElement>>(CreateAppDriver);
         }
 
@@ -49,7 +50,8 @@ namespace SpecFlow.Actions.WindowsAppDriver
 
             if (_lazyDriver.IsValueCreated)
             {
-                Current.CloseApp();
+                if (_windowsAppDriverConfiguration.CloseAppAutomatically)
+                    Current.CloseApp();
             }
 
             _isDisposed = true;

--- a/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/AppDriverCLI.cs
+++ b/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/AppDriverCLI.cs
@@ -25,7 +25,7 @@ namespace SpecFlow.Actions.WindowsAppDriver
 
             if (path != null)
             {
-                _appDriverProcess = Process.Start(path); 
+                _appDriverProcess = Process.Start(path, _windowsAppDriverConfiguration.WindowsAppDriverPort != null ? _windowsAppDriverConfiguration.WindowsAppDriverPort.ToString() : "");
             }
         }
 

--- a/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/Configuration/WindowsAppDriverConfiguration.cs
+++ b/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/Configuration/WindowsAppDriverConfiguration.cs
@@ -41,5 +41,9 @@ namespace SpecFlow.Actions.WindowsAppDriver.Configuration
         public string? WindowsAppDriverPath => _specflowJsonPart.Value.WindowsAppDriver.WindowsAppDriverPath;
 
         public bool? EnableScreenshots => _specflowJsonPart.Value.WindowsAppDriver.EnableScreenshots;
+
+        public int? WindowsAppDriverPort => _specflowJsonPart.Value.WindowsAppDriver.WindowsAppDriverPort;
+
+        public bool CloseAppAutomatically => _specflowJsonPart.Value.WindowsAppDriver.CloseAppAutomatically ?? true;
     }
 }

--- a/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/Configuration/WindowsAppDriverJsonPart.cs
+++ b/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/Configuration/WindowsAppDriverJsonPart.cs
@@ -9,6 +9,10 @@ namespace SpecFlow.Actions.WindowsAppDriver.Configuration
 
         [JsonInclude] public string? WindowsAppDriverPath { get; set; }
 
+        [JsonInclude] public int? WindowsAppDriverPort { get; set; }
+
         [JsonInclude] public bool? EnableScreenshots { get; set; }
+
+        [JsonInclude] public bool? CloseAppAutomatically { get; set; }
     }
 }

--- a/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/WindowsAppDriverOptions.cs
+++ b/Plugins/SpecFlow.Actions.WindowsAppDriver/SpecFlow.Actions.WindowsAppDriver/WindowsAppDriverOptions.cs
@@ -1,9 +1,7 @@
 ﻿using OpenQA.Selenium.Appium;
-using SpecFlow.Actions.Appium;
 using SpecFlow.Actions.Appium.Configuration.WindowsAppDriver;
 using SpecFlow.Actions.Appium.Driver;
 using System;
-using System.Collections;
 using System.IO;
 
 namespace SpecFlow.Actions.WindowsAppDriver
@@ -11,14 +9,12 @@ namespace SpecFlow.Actions.WindowsAppDriver
     internal class WindowsAppDriverOptions : IDriverOptions
     {
         private readonly IWindowsAppDriverConfiguration _windowsAppDriverConfiguration;
-        private readonly Lazy<AppiumOptions> _appiumOptionsLazy;
 
-        public AppiumOptions Current => _appiumOptionsLazy.Value;
+        public AppiumOptions Current => GetOptions();
 
         internal WindowsAppDriverOptions(IWindowsAppDriverConfiguration windowsAppDriverConfiguration)
         {
             _windowsAppDriverConfiguration = windowsAppDriverConfiguration;
-            _appiumOptionsLazy = new Lazy<AppiumOptions>(GetOptions);
         }
 
         private AppiumOptions GetOptions()


### PR DESCRIPTION
This Pull request contains some improvements for SpecFlow.Actions.WindowsAppDriver that were necessary to make it work for our purposes. It contains the following changes:

1. `WindowsAppDriverOptions.Current` isn't lazy (and therefore "cached") anymore. The reason is, that we have to modify the capabilities after each scenario. We are doing this by modifying the WindowsAppDriverConfiguration. These changes do not take effect, when `WindowsAppDriverOptions.Current` is lazy.
2. Introduced new option `WindowsAppDriverPort`. On some computers in our company the WinAppDriver default port is already in use by some Windows process. Without the ability to configure the port to be used for the WinAppDriver, it is impossible to launch the tests on these computers.
3. Introduced new option `CloseAppAutomatically`. Currently, the AUT will be automatically closed in `AppDriver.Dispose`. Unfortunately, this doesn't always work for the application we are testing, because sometimes there are additional steps necessary to really close the app. Therefore, we are handling the termination of the application ourselves after each scenario. But then `Current.CloseApp()` will throw an exception in `AppDriver.Dispose`. To maintain backwards compatibility, the setting is optional and default to `true`.