### PR TITLE
fix a typo

### DIFF
--- a/Plugins/SpecFlow.Actions.Docker/Readme.md
+++ b/Plugins/SpecFlow.Actions.Docker/Readme.md
@@ -7,7 +7,7 @@ This SpecFlow.Actions will help you by using Docker together with SpecFlow.
 ## Included Features
 
 - Start Docker containers from Dockerfile/docker-compose.yml at the start of the test scenario.
-- Stop Docker containers from Dockerfile/docker-compose.yml at the start of the test scenario.
+- Stop Docker containers from Dockerfile/docker-compose.yml at the end of the test scenario.
 
 ## Configuration
 


### PR DESCRIPTION
there was a typo in specflow.action.docker's readme