### PR TITLE
Remove leading foreword slash from Playwright setup URL link

### DIFF
--- a/Plugins/SpecFlow.Actions.Playwright/Readme.md
+++ b/Plugins/SpecFlow.Actions.Playwright/Readme.md
@@ -8,7 +8,7 @@ This SpecFlow.Action will help you use [Playwright](https://playwright.dev/) tog
 
 ### Setup
 
-You will need to read through the [setup process for Playwright](https://playwright.dev/dotnet/docs/intro/) so that your environment is ready for execution.
+You will need to read through the [setup process for Playwright](https://playwright.dev/dotnet/docs/intro) so that your environment is ready for execution.
 
 ## Included Features
 


### PR DESCRIPTION
Currently when following the Playwright setup URL link for some reason it returns: "This page is not available for .NET." (Failed to load resource: the server responded with a status of 404 () ) 

Simply removing the foreword slash seems to resolve the link fine.